### PR TITLE
#186813831 Add: Read request body in the middleware for various version of fastapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Moesif has validated `Moesif.Middleware` against the following framework.
 |         | Framework Version |
 |---------|-------------------|
 | fastapi | > 0.51.0 - 0.78.0 |
+| fastapi |  0.108.0          |
 
 ## Other integrations
 

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -218,7 +218,7 @@ def mask_event(eventmodel):
 moesif_settings = {
     'APPLICATION_ID': 'Your Moesif Application Id',
     'LOG_BODY': True,
-    'DEBUG': True,
+    'DEBUG': False,
     'IDENTIFY_USER': identify_user,
     'IDENTIFY_COMPANY': identify_company,
     'GET_SESSION_TOKEN': get_token,

--- a/examples/fastapi/requirements.txt
+++ b/examples/fastapi/requirements.txt
@@ -1,8 +1,8 @@
 moesifasgi
 uvicorn
 passlib==1.7.4
-moesifapi==1.4.0
-moesifpythonrequest==0.2.0
+moesifapi==1.4.1
+moesifpythonrequest==0.3.2
 fastapi==0.78.0
 jose==1.0.0
 python-jose==3.3.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.5',
+    version='0.1.6',
 
     description='Moesif Middleware for Python ASGI based platforms (FastAPI & Others)',
     long_description=long_description,


### PR DESCRIPTION
Add: Read request body in the middleware for various version of fastapi 
Fix: Use moesif_settings while reading event queue size config 
Refactor: Example dependencies
Refactor: Update README.md
Bump version to 0.1.6